### PR TITLE
Add Automatic-Module-Name to created JAR

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,12 @@ java {
     withJavadocJar()
 }
 
+tasks.jar {
+    manifest {
+        attributes("Automatic-Module-Name" to "net.minecrell.terminalconsole")
+    }
+}
+
 tasks.withType<Test> {
     useJUnitPlatform()
 }


### PR DESCRIPTION
Provides basic, but not comprehensive, support for the Java Module System. A stable module name is the first step for compatibility with JPMS.

I chose `net.minecrell.terminalconsole` as the module name, which reflects the convention that the module name is usually, but not always, the base package name.

I've checked that the built jar correctly includes the manifest attribute.