### PR TITLE
Add module descriptor inside multi-release jar (Fixes #21)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: bionic
 
 language: java
-jdk: openjdk8
+jdk: openjdk11
 
 install: true
 script: ./gradlew build

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,8 +14,10 @@ sourceSets.create("java11") {
     java.srcDir("src/main/java")
 }
 
-sourceSets.create("intTest") {
-}
+sourceSets.create("intTest")
+
+configurations["java11CompileClasspath"].extendsFrom(configurations.compileClasspath.get())
+configurations["intTestImplementation"].extendsFrom(configurations.api.get())
 
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8
@@ -35,6 +37,7 @@ dependencies {
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.7.2")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.7.2")
+    "intTestImplementation"(files(tasks.named<Jar>("jar").get().archiveFile))
 }
 
 java {
@@ -60,7 +63,6 @@ tasks.named<JavaCompile>("compileJava") {
 tasks.named<JavaCompile>("compileJava11Java") {
     options.release.set(11)
     options.javaModuleVersion.set(project.version as String)
-    classpath = classpath.plus(sourceSets["main"].compileClasspath)
 }
 
 tasks.named<JavaCompile>("compileIntTestJava") {
@@ -71,13 +73,8 @@ tasks.withType<Test> {
     useJUnitPlatform()
 }
 
-val compileIntTestTask = tasks.named<JavaCompile>("compileIntTestJava") {
-    val jarTask = tasks.named<Jar>("jar").get()
-    dependsOn(jarTask)
-    val mainJar = jarTask.archiveFile.get()
-    classpath = sourceSets["main"].runtimeClasspath.plus(files(mainJar))
-}
-tasks.build { dependsOn(compileIntTestTask) }
+val compileIntTestTask = tasks.named<JavaCompile>("compileIntTestJava").get()
+tasks.check { dependsOn(compileIntTestTask) }
 
 val isSnapshot = version.toString().endsWith("-SNAPSHOT")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,9 @@ sourceSets.create("java11") {
     java.srcDir("src/main/java")
 }
 
+sourceSets.create("intTest") {
+}
+
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8
 }
@@ -60,9 +63,21 @@ tasks.named<JavaCompile>("compileJava11Java") {
     classpath = classpath.plus(sourceSets["main"].compileClasspath)
 }
 
+tasks.named<JavaCompile>("compileIntTestJava") {
+    options.release.set(11)
+}
+
 tasks.withType<Test> {
     useJUnitPlatform()
 }
+
+val compileIntTestTask = tasks.named<JavaCompile>("compileIntTestJava") {
+    val jarTask = tasks.named<Jar>("jar").get()
+    dependsOn(jarTask)
+    val mainJar = jarTask.archiveFile.get()
+    classpath = sourceSets["main"].runtimeClasspath.plus(files(mainJar))
+}
+tasks.build { dependsOn(compileIntTestTask) }
 
 val isSnapshot = version.toString().endsWith("-SNAPSHOT")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -73,8 +73,7 @@ tasks.withType<Test> {
     useJUnitPlatform()
 }
 
-val compileIntTestTask = tasks.named<JavaCompile>("compileIntTestJava").get()
-tasks.check { dependsOn(compileIntTestTask) }
+tasks.check { dependsOn(tasks.named("compileIntTestJava")) }
 
 val isSnapshot = version.toString().endsWith("-SNAPSHOT")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.7.2")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.7.2")
-    "intTestImplementation"(files(tasks.named<Jar>("jar").get().archiveFile))
+    "intTestImplementation"(files(tasks.named("jar")))
 }
 
 java {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,11 @@ plugins {
 val artifactId = project.name.toLowerCase()
 base.archivesBaseName = artifactId
 
+sourceSets.create("java11") {
+    java.srcDir("src/main/java11")
+    java.srcDir("src/main/java")
+}
+
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8
 }
@@ -18,8 +23,8 @@ repositories {
 }
 
 dependencies {
-    api("org.apache.logging.log4j:log4j-core:2.8.1")
-    annotationProcessor("org.apache.logging.log4j:log4j-core:2.8.1")
+    api("org.apache.logging.log4j:log4j-core:2.14.1")
+    annotationProcessor("org.apache.logging.log4j:log4j-core:2.14.1")
 
     api("org.jline:jline-reader:3.20.0")
 
@@ -37,7 +42,22 @@ java {
 tasks.jar {
     manifest {
         attributes("Automatic-Module-Name" to "net.minecrell.terminalconsole")
+        attributes("Multi-Release" to "true")
     }
+    into("META-INF/versions/11") {
+        from(sourceSets["java11"].output)
+        include("module-info.class")
+    }
+}
+
+tasks.named<JavaCompile>("compileJava") {
+    options.release.set(8)
+}
+
+tasks.named<JavaCompile>("compileJava11Java") {
+    options.release.set(11)
+    options.javaModuleVersion.set(project.version as String)
+    classpath = classpath.plus(sourceSets["main"].compileClasspath)
 }
 
 tasks.withType<Test> {

--- a/src/intTest/java/module-info.java
+++ b/src/intTest/java/module-info.java
@@ -1,0 +1,27 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Minecrell <https://github.com/Minecrell>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+module net.minecrell.terminalconsole.it {
+  requires net.minecrell.terminalconsole;
+}

--- a/src/intTest/java/module-info.java
+++ b/src/intTest/java/module-info.java
@@ -23,5 +23,5 @@
  */
 
 module net.minecrell.terminalconsole.it {
-  requires net.minecrell.terminalconsole;
+    requires net.minecrell.terminalconsole;
 }

--- a/src/intTest/java/net/minecrell/terminalconsole/it/jpms/Compilation.java
+++ b/src/intTest/java/net/minecrell/terminalconsole/it/jpms/Compilation.java
@@ -1,0 +1,35 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Minecrell <https://github.com/Minecrell>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package net.minecrell.terminalconsole.it.jpms;
+
+import org.apache.logging.log4j.core.LogEvent;
+import net.minecrell.terminalconsole.TerminalConsoleAppender;
+
+public class Compilation {
+
+  public void useTCA(TerminalConsoleAppender tca) {
+    tca.append((LogEvent) null);    
+  }
+}

--- a/src/intTest/java/net/minecrell/terminalconsole/it/jpms/Compilation.java
+++ b/src/intTest/java/net/minecrell/terminalconsole/it/jpms/Compilation.java
@@ -29,7 +29,7 @@ import net.minecrell.terminalconsole.TerminalConsoleAppender;
 
 public class Compilation {
 
-  public void useTCA(TerminalConsoleAppender tca) {
-    tca.append((LogEvent) null);    
-  }
+    public void useTCA(TerminalConsoleAppender tca) {
+        tca.append((LogEvent) null);    
+    }
 }

--- a/src/main/java11/module-info.java
+++ b/src/main/java11/module-info.java
@@ -23,12 +23,12 @@
  */
 
 module net.minecrell.terminalconsole {
-    exports net.minecrell.terminalconsole;
-    exports net.minecrell.terminalconsole.util;
-
+    requires org.apache.logging.log4j;
     requires transitive org.apache.logging.log4j.core;
     requires static org.checkerframework.checker.qual;
     requires transitive org.jline.terminal;
     requires transitive org.jline.reader;
-    requires org.apache.logging.log4j;
+
+    exports net.minecrell.terminalconsole;
+    exports net.minecrell.terminalconsole.util;
 }

--- a/src/main/java11/module-info.java
+++ b/src/main/java11/module-info.java
@@ -1,0 +1,34 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Minecrell <https://github.com/Minecrell>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+module net.minecrell.terminalconsole {
+    exports net.minecrell.terminalconsole;
+    exports net.minecrell.terminalconsole.util;
+
+    requires transitive org.apache.logging.log4j.core;
+    requires static org.checkerframework.checker.qual;
+    requires transitive org.jline.terminal;
+    requires transitive org.jline.reader;
+    requires org.apache.logging.log4j;
+}


### PR DESCRIPTION
The module descriptor is compiled with Java 11 and placed into a [multi-release JAR](https://openjdk.java.net/jeps/238). Thus, this raises the build-time requirement for TCA to Java 11.

To maintain Java 8 compatibility for the rest of the sources, the main compilation task uses the release compiler flag. For example, calling `List.of()` causes compilation will fail. The main classes also have class file major version 52 per javap.

The Log4j version was bumped since 2.8.1 is too old that it does not declare a module name.