### PR TITLE
Update dependencies; explicitly set UTF-8 encoding

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     id("org.cadixdev.licenser") version "0.6.1"
 }
 
-base.archivesName(project.name.toLowerCase())
+base.archivesName(project.name.lowercase())
 
 sourceSets.create("java11") {
     java.srcDir("src/main/java11")
@@ -27,15 +27,15 @@ repositories {
 }
 
 dependencies {
-    api("org.apache.logging.log4j:log4j-core:2.14.1")
-    annotationProcessor("org.apache.logging.log4j:log4j-core:2.14.1")
+    api("org.apache.logging.log4j:log4j-core:2.21.1")
+    annotationProcessor("org.apache.logging.log4j:log4j-core:2.21.1")
 
-    api("org.jline:jline-reader:3.20.0")
+    api("org.jline:jline-reader:3.24.1")
 
-    compileOnly("org.checkerframework:checker-qual:3.17.0")
+    compileOnly("org.checkerframework:checker-qual:3.32.0")
 
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.7.2")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.7.2")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.2")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.2")
     "intTestImplementation"(files(tasks.named("jar")))
 }
 
@@ -57,15 +57,18 @@ tasks.jar {
 
 tasks.named<JavaCompile>("compileJava") {
     options.release.set(8)
+    options.encoding = "UTF-8"
 }
 
 tasks.named<JavaCompile>("compileJava11Java") {
     options.release.set(11)
     options.javaModuleVersion.set(project.version as String)
+    options.encoding = "UTF-8"
 }
 
 tasks.named<JavaCompile>("compileIntTestJava") {
     options.release.set(11)
+    options.encoding = "UTF-8"
 }
 
 tasks.withType<Test> {
@@ -80,7 +83,7 @@ publishing {
     publications {
         register<MavenPublication>("mavenJava") {
             from(components["java"])
-            artifactId = project.name.toLowerCase()
+            artifactId = project.name.lowercase()
 
             pom {
                 val url: String by project

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Did a quick test, everything seems to work so far. 
 explicitly set UTF-8 encoding because I was getting an "illegal character" error at the section symbol (§) during build.

The Log4J2 version in HEAD/master is vulnerable to Log4shell btw !!